### PR TITLE
Upstream changes to library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,8 @@ conan_user = "ess-dmsc"
 conan_pkg_channel = "testing"
 
 container_build_nodes = [
-  'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7'),
-  'ubuntu': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu1804')
+  'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
+  'ubuntu': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu1804-gcc8')
 ]
 
 package_builder = new ConanPackageBuilder(this, container_build_nodes, conan_pkg_channel)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ import ecdcpipeline.ConanPackageBuilder
 project = "conan-Qt-Color-Widgets"
 
 conan_user = "ess-dmsc"
-conan_pkg_channel = "testing"
+conan_pkg_channel = "stable"
 
 container_build_nodes = [
   'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ conan_pkg_channel = "testing"
 
 container_build_nodes = [
   'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
-  'ubuntu': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu1804-gcc8')
+  'ubuntu2004': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2004')
 ]
 
 package_builder = new ConanPackageBuilder(this, container_build_nodes, conan_pkg_channel)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ import ecdcpipeline.ConanPackageBuilder
 project = "conan-Qt-Color-Widgets"
 
 conan_user = "ess-dmsc"
-conan_pkg_channel = "stable"
+conan_pkg_channel = "testing"
 
 container_build_nodes = [
   'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7'),

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ target_link_libraries(my_target
 If you are a contributor and wish to update this recipe to use the latest version of the target library:
 
 * make a branch
-* switch `channel` in [Jenkinsfile](Jenkinsfile) from `stable` to `testing`
-* change the commit hash to point to new version:
-  * in [conanfile.py](conanfile.py) at `version=`
-  * in this README, under the ["Using"](#using) section above
+* change `channel` in [Jenkinsfile](Jenkinsfile) from "stable" to "testing"
+* in [conanfile.py](conanfile.py) change `version=` to the hash (first 7 hex letters) of the commit that you want to package
 * push and massage until the job succeeds on [Jenkins](https://jenkins.esss.dk/dm/job/ess-dmsc/job/conan-Qt-Color-Widgets/)
 * ideally, test new version of package with actual projects that use it
-* switch `channel` back to `stable` and make a merge request
+* update the conan package name in code example, under the ["Using the package"](#using-the-package) section above
+* change `channel` back to "stable" in [Jenkinsfile](Jenkinsfile)
+* make a merge request

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Qt-Color-Widgets conan package
+# QtColorWidgets conan recipe
 
 [![Build Status](https://jenkins.esss.dk/dm/job/ess-dmsc/job/conan-Qt-Color-Widgets/job/master/badge/icon)](https://jenkins.esss.dk/dm/job/ess-dmsc/job/conan-Qt-Color-Widgets/job/master/)
 
-Conan package recipe for [Qt-Color-Widgets](https://github.com/ess-dmsc/Qt-Color-Widgets).
+Conan package recipe for [QtColorWidgets](https://github.com/ess-dmsc/Qt-Color-Widgets), an improved QColorDialog and several other color-related widgets.
 
 ## Updating
 To update to new version:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# conan-Qt-Color-Widgets
-A Conan package for Qt-Color-Widgets
+# Qt-Color-Widgets conan package
+
+[![Build Status](https://jenkins.esss.dk/dm/job/ess-dmsc/job/conan-Qt-Color-Widgets/job/master/badge/icon)](https://jenkins.esss.dk/dm/job/ess-dmsc/job/conan-Qt-Color-Widgets/job/master/)
+
+Conan package recipe for [Qt-Color-Widgets](https://github.com/ess-dmsc/Qt-Color-Widgets).
+
+## Updating
+To update to new version:
+* make a branch 
+* switch `channel` in [Jenkinsfile](Jenkinsfile) from `stable` to `testing`
+* in [conanfile.py](conanfile.py), change the commit hash to point to new version:
+  * in `version=`; and
+  * under `def source(self):`
+* push and massage until the job succeefds on [Jenkins](https://jenkins.esss.dk/dm/job/ess-dmsc/job/conan-Qt-Color-Widgets/)
+* switch `channel` back to `stable` and make a merge request

--- a/README.md
+++ b/README.md
@@ -1,15 +1,37 @@
-# QtColorWidgets conan recipe
+# conan-Qt-Color-Widgets
 
 [![Build Status](https://jenkins.esss.dk/dm/job/ess-dmsc/job/conan-Qt-Color-Widgets/job/master/badge/icon)](https://jenkins.esss.dk/dm/job/ess-dmsc/job/conan-Qt-Color-Widgets/job/master/)
 
 Conan package recipe for [QtColorWidgets](https://github.com/ess-dmsc/Qt-Color-Widgets), an improved QColorDialog and several other color-related widgets.
 
+This repository tracks the recipe for generating the conan package. You should not have to run these steps yourself but instead simply fetch the package from the the conan remote server as described below.
+
+## Using
+
+See the DMSC [conan-configuration repository](https://github.com/ess-dmsc/conan-configuration) for how to configure your remote.
+
+In `conanfile.txt`:
+
+```
+Qt-Color-Widgets/9f4e052@ess-dmsc/stable
+```
+
+In CMake:
+```
+target_link_libraries(my_target
+  PRIVATE QtColorWidgets
+)
+```
+
 ## Updating
-To update to new version:
-* make a branch 
+
+If you are a contributor and wish to update this recipe to use the latest version of the target library:
+
+* make a branch
 * switch `channel` in [Jenkinsfile](Jenkinsfile) from `stable` to `testing`
-* in [conanfile.py](conanfile.py), change the commit hash to point to new version:
-  * in `version=`; and
-  * under `def source(self):`
-* push and massage until the job succeefds on [Jenkins](https://jenkins.esss.dk/dm/job/ess-dmsc/job/conan-Qt-Color-Widgets/)
+* change the commit hash to point to new version:
+  * in [conanfile.py](conanfile.py) at `version=`
+  * in this README, under the ["Using"](#using) section above
+* push and massage until the job succeeds on [Jenkins](https://jenkins.esss.dk/dm/job/ess-dmsc/job/conan-qplot/)
+* ideally, test new version of package with actual projects that use it
 * switch `channel` back to `stable` and make a merge request

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Conan package recipe for [QtColorWidgets](https://github.com/ess-dmsc/Qt-Color-W
 
 This repository tracks the recipe for generating the conan package. You should not have to run these steps yourself but instead simply fetch the package from the the conan remote server as described below.
 
-## Using
+## Using the package
 
 See the DMSC [conan-configuration repository](https://github.com/ess-dmsc/conan-configuration) for how to configure your remote.
 
@@ -23,7 +23,7 @@ target_link_libraries(my_target
 )
 ```
 
-## Updating
+## Updating the recipe
 
 If you are a contributor and wish to update this recipe to use the latest version of the target library:
 
@@ -32,6 +32,6 @@ If you are a contributor and wish to update this recipe to use the latest versio
 * change the commit hash to point to new version:
   * in [conanfile.py](conanfile.py) at `version=`
   * in this README, under the ["Using"](#using) section above
-* push and massage until the job succeeds on [Jenkins](https://jenkins.esss.dk/dm/job/ess-dmsc/job/conan-qplot/)
+* push and massage until the job succeeds on [Jenkins](https://jenkins.esss.dk/dm/job/ess-dmsc/job/conan-Qt-Color-Widgets/)
 * ideally, test new version of package with actual projects that use it
 * switch `channel` back to `stable` and make a merge request

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from conans.util import files
 
 class QtColorWidgetsConan(ConanFile):
     name = "Qt-Color-Widgets"
-    version = "a95f72e"
+    version = "5e19e67"
     license = "https://github.com/ess-dmsc/Qt-Color-Widgets/blob/master/COPYING"
     url = "<Package recipe repository url here, for issues about the package>"
     description = "<Description of Qt-Color-Widgets here>"
@@ -20,7 +20,7 @@ class QtColorWidgetsConan(ConanFile):
 
     def source(self):
         self.run("git clone https://github.com/ess-dmsc/Qt-Color-Widgets.git")
-        self.run("cd Qt-Color-Widgets && git checkout a95f72e && cd ..")
+        self.run("cd Qt-Color-Widgets && git checkout 5e19e67 && cd ..")
 
     def build(self):
         files.mkdir(self.build_dir)

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,9 +4,9 @@ from conans.util import files
 
 class QtColorWidgetsConan(ConanFile):
     name = "Qt-Color-Widgets"
-    version = "5e19e67"
+    version = "9f4e052"
     license = "https://github.com/ess-dmsc/Qt-Color-Widgets/blob/master/COPYING"
-    url = "https://github.com/ess-dmsc/conan-Qt-Color-Widgets"
+    url = "https://github.com/ess-dmsc/Qt-Color-Widgets"
     description = "Improved QColorDialog and several other color-related widgets."
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False]}
@@ -20,7 +20,7 @@ class QtColorWidgetsConan(ConanFile):
 
     def source(self):
         self.run("git clone https://github.com/ess-dmsc/Qt-Color-Widgets.git")
-        self.run("cd Qt-Color-Widgets && git checkout 5e19e67 && cd ..")
+        self.run("cd Qt-Color-Widgets && git checkout {} && cd ..".format(self.version))
 
     def build(self):
         files.mkdir(self.build_dir)

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,8 +6,8 @@ class QtColorWidgetsConan(ConanFile):
     name = "Qt-Color-Widgets"
     version = "5e19e67"
     license = "https://github.com/ess-dmsc/Qt-Color-Widgets/blob/master/COPYING"
-    url = "<Package recipe repository url here, for issues about the package>"
-    description = "<Description of Qt-Color-Widgets here>"
+    url = "https://github.com/ess-dmsc/conan-Qt-Color-Widgets"
+    description = "Improved QColorDialog and several other color-related widgets."
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False]}
     default_options = "shared=False"

--- a/conanfile.py
+++ b/conanfile.py
@@ -49,4 +49,4 @@ class QtColorWidgetsConan(ConanFile):
         self.copy("*.a", dst="lib", keep_path=False)
 
     def package_info(self):
-        self.cpp_info.libs = ["QtColorWidgets-Qt52"]
+        self.cpp_info.libs = ["QtColorWidgets"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from conans.util import files
 
 class QtColorWidgetsConan(ConanFile):
     name = "Qt-Color-Widgets"
-    version = "5e19e67"
+    version = "e69a9f6"
     license = "https://github.com/ess-dmsc/Qt-Color-Widgets/blob/master/COPYING"
     url = "https://github.com/ess-dmsc/conan-Qt-Color-Widgets"
     description = "Improved QColorDialog and several other color-related widgets."
@@ -20,7 +20,7 @@ class QtColorWidgetsConan(ConanFile):
 
     def source(self):
         self.run("git clone https://github.com/ess-dmsc/Qt-Color-Widgets.git")
-        self.run("cd Qt-Color-Widgets && git checkout 5e19e67 && cd ..")
+        self.run("cd Qt-Color-Widgets && git checkout e69a9f6 && cd ..")
 
     def build(self):
         files.mkdir(self.build_dir)

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from conans.util import files
 
 class QtColorWidgetsConan(ConanFile):
     name = "Qt-Color-Widgets"
-    version = "e69a9f6"
+    version = "f31b4ee"
     license = "https://github.com/ess-dmsc/Qt-Color-Widgets/blob/master/COPYING"
     url = "https://github.com/ess-dmsc/conan-Qt-Color-Widgets"
     description = "Improved QColorDialog and several other color-related widgets."
@@ -15,12 +15,12 @@ class QtColorWidgetsConan(ConanFile):
 
     # The folder name when the *.tar.gz release is extracted
     folder_name = "Qt-Color-Widgets"
-    # The temporary build diirectory
+    # The temporary build directory
     build_dir = "./%s/build" % folder_name
 
     def source(self):
         self.run("git clone https://github.com/ess-dmsc/Qt-Color-Widgets.git")
-        self.run("cd Qt-Color-Widgets && git checkout e69a9f6 && cd ..")
+        self.run("cd Qt-Color-Widgets && git checkout f31b4ee && cd ..")
 
     def build(self):
         files.mkdir(self.build_dir)

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from conans.util import files
 
 class QtColorWidgetsConan(ConanFile):
     name = "Qt-Color-Widgets"
-    version = "f31b4ee"
+    version = "5e19e67"
     license = "https://github.com/ess-dmsc/Qt-Color-Widgets/blob/master/COPYING"
     url = "https://github.com/ess-dmsc/conan-Qt-Color-Widgets"
     description = "Improved QColorDialog and several other color-related widgets."
@@ -20,7 +20,7 @@ class QtColorWidgetsConan(ConanFile):
 
     def source(self):
         self.run("git clone https://github.com/ess-dmsc/Qt-Color-Widgets.git")
-        self.run("cd Qt-Color-Widgets && git checkout f31b4ee && cd ..")
+        self.run("cd Qt-Color-Widgets && git checkout 5e19e67 && cd ..")
 
     def build(self):
         files.mkdir(self.build_dir)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(Qt5 COMPONENTS Widgets PrintSupport REQUIRED)
 add_executable(example example.cpp)
 target_link_libraries(example
     ${CONAN_LIBS}
-    QtColorWidgets-Qt52
+    QtColorWidgets
     Qt5::Widgets
     Qt5::PrintSupport)
 


### PR DESCRIPTION
Bumping hash to use latest library with changes from upstream incorporated.
Readme has been updated and made nicer with link to Jenkins job and explanation on how to use the package and how to go about updating the recipe.