### PR TITLE
Add warning to README that recipe now uses conan v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ This repository tracks the recipe for generating the conan package. You should n
 
 See the DMSC [conan-configuration repository](https://github.com/ess-dmsc/conan-configuration) for how to configure your remote.
 
+:warning: This recipe now uses version 2 of conan which in not backward compatible with version 1.
+
 In `conanfile.txt`:
 
 ```
-Qt-Color-Widgets/9f4e052@ess-dmsc/stable
+qt-color-widgets/9f4e052@ess-dmsc/stable
 ```
 
 In CMake:


### PR DESCRIPTION
The work done in #6 may cause issues for users of this recipe. New in version 2 of conan is that package names **must** be all lower case

https://docs.conan.io/2/tutorial/creating_packages/create_your_first_package.html

This patch highlights the move to v2 so users are aware, and updates the string that should be used in `conanfile.txt`.